### PR TITLE
fix: sanitize orphaned tool_use blocks in conversation history

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -94,6 +94,7 @@ export {
   estimateMessageTokens,
   estimateTotalTokens,
   truncateOldMessages,
+  sanitizeHistory,
   ContextManager
 } from './context-manager.js'
 


### PR DESCRIPTION
When __ask_user__ or interruption occurs in executor, history is saved with tool_use blocks that have no matching tool_result. This causes LLM APIs to reject the request.

Add sanitizeHistory() that inserts dummy tool_result for any orphaned tool_use blocks. Called in manageContext and truncateOldMessages as a safety net (groupMessages still preserves real pairs during truncation).