### PR TITLE
#25 Add zero-dependency MCP client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Tuplet gives you exactly that. A powerful, multi-agent framework you plug into y
 - **Web browsing** — Navigate websites, extract data, interact with pages
 - **API requests with authentication** — Make HTTP requests to external services
 - **URL allowlisting** — Restrict which URLs the agent can access via `curl`/`browse` with wildcard patterns (`https://*.example.com/api/**`)
+- **MCP client** — Connect existing remote MCP servers (HubSpot, Close CRM, Google Calendar, ...) and expose their tools to the agent. Zero-dependency Streamable HTTP client — no SDK required. See [docs/mcp.md](docs/mcp.md)
 
 ### Multi-Provider
 
@@ -145,6 +146,7 @@ For other compatible vendors pass `baseURL` and `vendor` directly. See [Provider
 
 - [Quick Start](https://github.com/anetrebskii/tuplet/blob/main/docs/README.md)
 - [Tools](https://github.com/anetrebskii/tuplet/blob/main/docs/tools.md)
+- [MCP Servers](https://github.com/anetrebskii/tuplet/blob/main/docs/mcp.md)
 - [Skills](https://github.com/anetrebskii/tuplet/blob/main/docs/skills.md)
 - [Sub-Agents](https://github.com/anetrebskii/tuplet/blob/main/docs/sub-agents.md)
 - [Workspace](https://github.com/anetrebskii/tuplet/blob/main/docs/workspace.md)

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,150 @@
+# MCP Servers
+
+Tuplet is an MCP (Model Context Protocol) **client**. It connects to existing
+remote MCP servers, discovers their tools, and exposes them to the agent as
+native Tuplet tools. You don't build or host any server.
+
+The client is a zero-dependency Streamable HTTP implementation — no
+`@modelcontextprotocol/sdk` required. Only the **Streamable HTTP** transport is
+supported, which is what hosted servers use:
+
+| Service | Endpoint | Auth |
+|---|---|---|
+| HubSpot | `https://mcp.hubspot.com` | OAuth, or bearer token header |
+| Close CRM | `https://mcp.close.com/mcp` | OAuth, or API key via `Authorization` + `Close-Scope` headers |
+| Google Calendar | `https://calendarmcp.googleapis.com/mcp/v1` | OAuth 2.0 |
+
+> stdio (local subprocess) and legacy HTTP+SSE transports are not supported.
+
+## Quick start
+
+```ts
+import { Tuplet, ClaudeProvider, McpManager } from 'tuplet'
+
+const mcp = new McpManager([
+  {
+    name: 'hubspot',
+    description: 'HubSpot CRM — contacts, companies, deals',
+    url: 'https://mcp.hubspot.com',
+    headers: { Authorization: `Bearer ${process.env.HUBSPOT_TOKEN}` },
+  },
+  {
+    name: 'close',
+    description: 'Close CRM — leads and opportunities',
+    url: 'https://mcp.close.com/mcp',
+    headers: {
+      Authorization: `Bearer ${process.env.CLOSE_API_KEY}`,
+      'Close-Scope': 'mcp.read',
+    },
+  },
+])
+
+await mcp.connect()
+
+const agent = new Tuplet({
+  role: 'a sales assistant that works across HubSpot and Close',
+  llm: new ClaudeProvider({ apiKey: process.env.ANTHROPIC_API_KEY! }),
+  tools: [...mcp.getTools()],
+})
+
+const result = await agent.run('Find the HubSpot contact for acme.com and summarize their deals')
+console.log(result.response)
+
+await mcp.close()
+```
+
+## How tools appear to the agent
+
+- Each MCP tool is namespaced `${server}__${tool}` (e.g. `hubspot__crm_list_contacts`)
+  so tools from different servers never collide.
+- The MCP `inputSchema` is passed straight through as the tool's parameters.
+- Tool results (text / resource / image content blocks) are flattened to text.
+- MCP tools are **deferred** — they don't inflate the system prompt. The model
+  loads the ones it needs on demand via the built-in `__tool_search__` tool. A
+  server exposing 40 tools costs almost nothing until those tools are used.
+
+## Telling the agent what's connected
+
+`getTools()` gives the agent the tools, but not the *context* of which server is
+which. Wire `getPromptSection()` into the system prompt so the model knows what
+each server is for (it includes each server's description, tool count, and any
+usage instructions the server itself advertised):
+
+```ts
+const agent = new Tuplet({
+  role: `a sales assistant.\n\n${mcp.getPromptSection()}`,
+  llm,
+  tools: [...mcp.getTools()],
+})
+```
+
+Produces, for example:
+
+```
+## Connected MCP servers
+
+You have access to tools from the external MCP servers below. ...
+
+### hubspot — HubSpot CRM — contacts, companies, deals
+- Tools: 12 (prefixed `hubspot__`)
+
+### close — Close CRM — leads and opportunities
+- Tools: 8 (prefixed `close__`)
+```
+
+## Filtering tools
+
+Large servers may expose more tools than you want. Restrict per server:
+
+```ts
+{ name: 'hubspot', url: '...', allowTools: ['crm_list_contacts', 'crm_get_deal'] }
+// or
+{ name: 'hubspot', url: '...', denyTools: ['crm_delete_contact'] }
+```
+
+Names in `allowTools` / `denyTools` are the server's original (un-prefixed) tool
+names.
+
+## Auth
+
+Auth is header pass-through: whatever the server needs, put it in `headers`.
+These are sent on every request. Interactive browser OAuth flows are out of
+scope — obtain a token however your app does (OAuth exchange, API key) and pass
+it as a bearer or custom header. Servers that support API keys (e.g. Close) are
+the simplest to use from a backend.
+
+## Lifecycle
+
+`McpManager` is host-managed, which fits Tuplet's stateless design:
+
+- **Long-lived server**: construct the manager once, `connect()` at startup,
+  reuse `getTools()` across many `agent.run(...)` calls, `close()` on shutdown.
+- **Serverless / per-request**: construct and `connect()` at the start of the
+  request, `close()` at the end. `connect()` runs the servers in parallel.
+
+If a server fails to connect, `connect()` still connects the rest and throws an
+aggregate error listing the failures. Catch it to run degraded — `getTools()`
+and `getPromptSection()` only include servers that actually connected.
+
+## API
+
+```ts
+new McpManager(servers: McpServerConfig[])
+  .connect(): Promise<void>
+  .getTools(): Tool[]
+  .getServerInfo(): McpServerInfo[]
+  .getPromptSection(): string
+  .close(): Promise<void>
+
+interface McpServerConfig {
+  name: string                       // namespace for this server's tools
+  url: string                        // Streamable HTTP endpoint
+  headers?: Record<string, string>   // auth / scope headers
+  description?: string               // surfaced to the agent
+  allowTools?: string[]              // only expose these (original names)
+  denyTools?: string[]               // hide these (original names)
+}
+```
+
+For a single server you can use `McpConnection` directly; it takes the same
+config and exposes `connect()`, `getTools()`, `info()`, and `close()`.

--- a/examples/eating-consultant/.env.example
+++ b/examples/eating-consultant/.env.example
@@ -1,7 +1,18 @@
-ANTHROPIC_API_KEY=your-api-key-here
+OPENROUTER_API_KEY=your-openrouter-key-here
 
 # Optional: Langfuse tracing (https://langfuse.com)
 # When set, every agent run is sent to Langfuse as a trace.
 LANGFUSE_PUBLIC_KEY=pk-lf-...
 LANGFUSE_SECRET_KEY=sk-lf-...
 LANGFUSE_BASE_URL=https://us.cloud.langfuse.com
+
+# Optional: connect a remote MCP server. Set MCP_URL to enable.
+# Example — HubSpot (https://developers.hubspot.com/mcp):
+MCP_NAME=hubspot
+MCP_URL=https://mcp.hubspot.com
+MCP_AUTH=Bearer your-hubspot-token
+MCP_DESCRIPTION=HubSpot CRM - contacts, companies, deals
+# Close CRM only: sets the Close-Scope header (mcp.read | mcp.write_safe | mcp.write_destructive)
+# MCP_SCOPE=mcp.read
+# Extra headers as JSON:
+# MCP_HEADERS={"X-Extra":"1"}

--- a/examples/eating-consultant/.gitignore
+++ b/examples/eating-consultant/.gitignore
@@ -3,3 +3,4 @@ dist/
 .env
 runs/
 workspace-data/
+openrouter-logs/

--- a/examples/eating-consultant/src/index.ts
+++ b/examples/eating-consultant/src/index.ts
@@ -21,6 +21,8 @@ import {
   Workspace,
   FileWorkspaceProvider,
   RunRecorder,
+  McpManager,
+  type Tool,
   type Message,
   type SkillConfig,
   type ProgressUpdate,
@@ -254,6 +256,42 @@ async function main() {
   const logDir = process.env.OPENROUTER_LOG_DIR ?? "./openrouter-logs";
   mkdirSync(logDir, { recursive: true });
   let logCounter = 0;
+
+  // --- MCP server (optional) ---
+  // Connect a remote MCP server configured via .env. Example (HubSpot):
+  //   MCP_NAME=hubspot
+  //   MCP_URL=https://mcp.hubspot.com
+  //   MCP_AUTH=Bearer <token>           -> sent as the Authorization header
+  //   MCP_DESCRIPTION=HubSpot CRM
+  //   MCP_SCOPE=mcp.read                -> sent as Close-Scope (Close CRM only)
+  //   MCP_HEADERS={"X-Extra":"1"}       -> optional extra headers (JSON)
+  let mcp: McpManager | null = null;
+  let mcpTools: Tool[] = [];
+  let mcpSection = "";
+  if (process.env.MCP_URL) {
+    const headers: Record<string, string> = {};
+    if (process.env.MCP_AUTH) headers["Authorization"] = process.env.MCP_AUTH;
+    if (process.env.MCP_SCOPE) headers["Close-Scope"] = process.env.MCP_SCOPE;
+    if (process.env.MCP_HEADERS) Object.assign(headers, JSON.parse(process.env.MCP_HEADERS));
+    mcp = new McpManager([
+      {
+        name: process.env.MCP_NAME ?? "mcp",
+        url: process.env.MCP_URL,
+        description: process.env.MCP_DESCRIPTION,
+        headers,
+      },
+    ]);
+    try {
+      await mcp.connect();
+      mcpTools = mcp.getTools();
+      mcpSection = mcp.getPromptSection();
+      const info = mcp.getServerInfo()[0];
+      console.log(`MCP: connected to "${info.name}" — ${info.toolCount} tools`);
+    } catch (err) {
+      console.error(`MCP: failed to connect — ${err instanceof Error ? err.message : String(err)}`);
+      mcp = null;
+    }
+  }
 
   // Try the free Gemma tier first; fall back to the paid one when the free
   // tier is rate-limited, overloaded, or returns a transient error. Cost
@@ -523,6 +561,7 @@ Keep the tone supportive and practical.`,
   // Flush any buffered trace events before the process exits.
   const shutdownTracing = async () => {
     await traceProvider.shutdown();
+    if (mcp) await mcp.close();
   };
   process.on("beforeExit", shutdownTracing);
   process.on("SIGINT", async () => {
@@ -535,8 +574,9 @@ Keep the tone supportive and practical.`,
     role:
       "a nutrition consultant that helps users track meals, view nutrition progress, and plan their diet. " +
       "You have skills for specific workflows - activate them when the user's request matches. " +
-      "Present results in a friendly, encouraging way. Use Russian if user speaks Russian.",
-    tools: nutritionCounterTools,
+      "Present results in a friendly, encouraging way. Use Russian if user speaks Russian." +
+      (mcpSection ? `\n\n${mcpSection}` : ""),
+    tools: [...nutritionCounterTools, ...mcpTools],
     skills,
     agents: [],
     llm: llmProvider,

--- a/src/index.ts
+++ b/src/index.ts
@@ -276,6 +276,22 @@ export {
 // Built-in Agents
 export { exploreAgent, planAgent, getBuiltInAgents } from './built-in-agents/index.js'
 
+// MCP (Model Context Protocol) client
+export {
+  McpManager,
+  McpConnection,
+  McpHttpClient,
+  parseSseMessages,
+  sanitizeToolName,
+  normalizeSchema,
+  flattenContent,
+  type McpServerConfig,
+  type McpServerInfo,
+  type FetchLike,
+  type McpToolDef,
+  type McpCallResult
+} from './mcp/index.js'
+
 // Dataset (Run Recording, Replay & Testing)
 export {
   RunRecorder,

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,0 +1,137 @@
+/**
+ * MCP connection — connects to a single MCP server over Streamable HTTP and
+ * wraps its tools as native Tuplet tools.
+ */
+
+import type { Tool, ToolResult, JSONSchema } from '../types.js'
+import type { McpServerConfig, McpServerInfo } from './types.js'
+import { McpHttpClient, type FetchLike, type McpToolDef } from './http-client.js'
+
+const CLIENT_INFO = { name: 'tuplet', version: '1.0.0' }
+
+/** Content block shape returned by tools/call (subset we read). */
+interface McpContentBlock {
+  type?: string
+  text?: string
+  data?: string
+  mimeType?: string
+  resource?: { text?: string; uri?: string }
+}
+
+/** Tool names must match provider constraints (Anthropic/OpenAI): [A-Za-z0-9_-], <=64. */
+export function sanitizeToolName(name: string): string {
+  const cleaned = name.replace(/[^a-zA-Z0-9_-]/g, '_')
+  return cleaned.length > 64 ? cleaned.slice(0, 64) : cleaned
+}
+
+/** Coerce an MCP input schema into Tuplet's JSONSchema (passed straight to the API). */
+export function normalizeSchema(schema: unknown): JSONSchema {
+  if (schema && typeof schema === 'object' && (schema as { type?: string }).type === 'object') {
+    const s = schema as JSONSchema
+    return { ...s, properties: s.properties ?? {} }
+  }
+  return { type: 'object', properties: {} }
+}
+
+/** Flatten tools/call content blocks into a single text string for the model. */
+export function flattenContent(content: unknown): string {
+  if (!Array.isArray(content)) return ''
+  const parts: string[] = []
+  for (const block of content as McpContentBlock[]) {
+    if (!block || typeof block !== 'object') continue
+    if (block.type === 'text' && typeof block.text === 'string') {
+      parts.push(block.text)
+    } else if (block.type === 'resource' && block.resource) {
+      if (typeof block.resource.text === 'string') parts.push(block.resource.text)
+      else if (block.resource.uri) parts.push(`[resource: ${block.resource.uri}]`)
+    } else if (block.type === 'image') {
+      parts.push(`[image${block.mimeType ? ` ${block.mimeType}` : ''}]`)
+    } else {
+      parts.push(JSON.stringify(block))
+    }
+  }
+  return parts.join('\n')
+}
+
+export class McpConnection {
+  readonly config: McpServerConfig
+  private client: McpHttpClient | null = null
+  private rawTools: McpToolDef[] = []
+  private instructions?: string
+
+  constructor(config: McpServerConfig) {
+    this.config = config
+  }
+
+  get connected(): boolean {
+    return this.client !== null
+  }
+
+  /**
+   * Connect to the server and discover its tools.
+   * @param fetchImpl Optional fetch override (custom auth, testing).
+   */
+  async connect(fetchImpl?: FetchLike): Promise<void> {
+    const client = new McpHttpClient(this.config.url, this.config.headers ?? {}, fetchImpl)
+    const { instructions } = await client.initialize(CLIENT_INFO)
+    this.instructions = instructions
+    this.rawTools = await client.listTools()
+    this.client = client
+  }
+
+  private filteredTools(): McpToolDef[] {
+    const { allowTools, denyTools } = this.config
+    let list = this.rawTools
+    if (allowTools) list = list.filter(t => allowTools.includes(t.name))
+    if (denyTools) list = list.filter(t => !denyTools.includes(t.name))
+    return list
+  }
+
+  /** Wrap this server's tools as Tuplet tools. Throws if not connected. */
+  getTools(): Tool[] {
+    const client = this.client
+    if (!client) {
+      throw new Error(`MCP server "${this.config.name}" is not connected — call connect() first`)
+    }
+    return this.filteredTools().map(raw => this.wrapTool(client, raw))
+  }
+
+  private wrapTool(client: McpHttpClient, raw: McpToolDef): Tool {
+    const serverName = this.config.name
+    const originalName = raw.name
+    return {
+      name: sanitizeToolName(`${serverName}__${originalName}`),
+      description: raw.description || `${originalName} (via ${serverName} MCP server)`,
+      parameters: normalizeSchema(raw.inputSchema),
+      execute: async (params: Record<string, unknown>): Promise<ToolResult> => {
+        try {
+          const res = await client.callTool(originalName, params)
+          const text = flattenContent(res.content)
+          if (res.isError) {
+            return { success: false, error: text || `MCP tool ${originalName} returned an error` }
+          }
+          return { success: true, data: text }
+        } catch (err) {
+          return { success: false, error: err instanceof Error ? err.message : String(err) }
+        }
+      },
+    }
+  }
+
+  info(): McpServerInfo {
+    return {
+      name: this.config.name,
+      description: this.config.description,
+      instructions: this.instructions,
+      toolCount: this.connected ? this.filteredTools().length : 0,
+      connected: this.connected,
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.client) {
+      await this.client.close()
+      this.client = null
+    }
+  }
+}

--- a/src/mcp/http-client.ts
+++ b/src/mcp/http-client.ts
@@ -1,0 +1,175 @@
+/**
+ * Minimal MCP Streamable HTTP client — JSON-RPC 2.0 over HTTP POST, zero deps.
+ *
+ * Implements just what an agent needs against a remote MCP server:
+ * initialize handshake, tools/list, tools/call. Server-initiated streams and
+ * resumability are out of scope (we do synchronous request/response only).
+ *
+ * A response may come back as `application/json` (one message) or
+ * `text/event-stream` (SSE-framed); both are handled.
+ */
+
+const PROTOCOL_VERSION = '2025-06-18'
+
+export type FetchLike = (url: string, init: RequestInit) => Promise<Response>
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0'
+  id?: number
+  result?: unknown
+  error?: { code: number; message: string; data?: unknown }
+}
+
+export interface McpToolDef {
+  name: string
+  description?: string
+  inputSchema: unknown
+}
+
+export interface McpCallResult {
+  content: unknown
+  isError?: boolean
+}
+
+/** Parse the `data:` payloads out of an SSE body into JSON-RPC messages. */
+export function parseSseMessages(raw: string): JsonRpcResponse[] {
+  const out: JsonRpcResponse[] = []
+  for (const chunk of raw.split(/\r?\n\r?\n/)) {
+    const dataLines = chunk
+      .split(/\r?\n/)
+      .filter(line => line.startsWith('data:'))
+      .map(line => line.slice(5).replace(/^ /, ''))
+    if (dataLines.length === 0) continue
+    try {
+      out.push(JSON.parse(dataLines.join('\n')) as JsonRpcResponse)
+    } catch {
+      // Ignore non-JSON events (comments, pings).
+    }
+  }
+  return out
+}
+
+async function readMessage(res: Response, id: number): Promise<JsonRpcResponse> {
+  const contentType = res.headers.get('content-type') ?? ''
+  const text = await res.text()
+  if (contentType.includes('text/event-stream')) {
+    const messages = parseSseMessages(text)
+    const match =
+      messages.find(m => m.id === id) ??
+      messages.find(m => m.result !== undefined || m.error !== undefined)
+    if (!match) throw new Error(`No JSON-RPC response in SSE stream for id ${id}`)
+    return match
+  }
+  if (!text.trim()) throw new Error('Empty response from MCP server')
+  return JSON.parse(text) as JsonRpcResponse
+}
+
+export class McpHttpClient {
+  private url: string
+  private headers: Record<string, string>
+  private fetchImpl: FetchLike
+  private sessionId?: string
+  private protocolVersion = PROTOCOL_VERSION
+  private nextId = 1
+  private initialized = false
+
+  constructor(url: string, headers: Record<string, string> = {}, fetchImpl?: FetchLike) {
+    this.url = url
+    this.headers = headers
+    const globalFetch = (globalThis as { fetch?: FetchLike }).fetch
+    this.fetchImpl = fetchImpl ?? globalFetch!
+    if (!this.fetchImpl) {
+      throw new Error('global fetch is unavailable; pass a fetch implementation to McpHttpClient')
+    }
+  }
+
+  async initialize(clientInfo: { name: string; version: string }): Promise<{ instructions?: string }> {
+    const result = (await this.request('initialize', {
+      protocolVersion: PROTOCOL_VERSION,
+      capabilities: {},
+      clientInfo,
+    }, true)) as { protocolVersion?: string; instructions?: string } | undefined
+    if (result?.protocolVersion) this.protocolVersion = result.protocolVersion
+    this.initialized = true
+    await this.notify('notifications/initialized')
+    return { instructions: result?.instructions }
+  }
+
+  async listTools(): Promise<McpToolDef[]> {
+    const result = (await this.request('tools/list', {})) as { tools?: McpToolDef[] } | undefined
+    return result?.tools ?? []
+  }
+
+  async callTool(name: string, args: Record<string, unknown>): Promise<McpCallResult> {
+    return (await this.request('tools/call', { name, arguments: args })) as McpCallResult
+  }
+
+  async close(): Promise<void> {
+    if (this.sessionId) {
+      try {
+        await this.fetchImpl(this.url, { method: 'DELETE', headers: this.buildHeaders() })
+      } catch {
+        // Best-effort session teardown.
+      }
+      this.sessionId = undefined
+    }
+    this.initialized = false
+  }
+
+  private buildHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream',
+      ...this.headers,
+    }
+    if (this.sessionId) headers['mcp-session-id'] = this.sessionId
+    if (this.initialized) headers['mcp-protocol-version'] = this.protocolVersion
+    return headers
+  }
+
+  private async request(method: string, params: unknown, captureSession = false): Promise<unknown> {
+    const id = this.nextId++
+    const res = await this.fetchImpl(this.url, {
+      method: 'POST',
+      headers: this.buildHeaders(),
+      body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+    })
+    if (captureSession) {
+      const sid = res.headers.get('mcp-session-id')
+      if (sid) this.sessionId = sid
+    }
+    if (!res.ok) {
+      throw new Error(`MCP HTTP ${res.status} for ${method}: ${await safeText(res)}`)
+    }
+    const message = await readMessage(res, id)
+    if (message.error) {
+      throw new Error(`MCP error ${message.error.code} for ${method}: ${message.error.message}`)
+    }
+    return message.result
+  }
+
+  private async notify(method: string, params?: unknown): Promise<void> {
+    const res = await this.fetchImpl(this.url, {
+      method: 'POST',
+      headers: this.buildHeaders(),
+      body: JSON.stringify({ jsonrpc: '2.0', method, params }),
+    })
+    // Notifications return 202 with no useful body — drain and move on.
+    const body = res.body as { cancel?: () => Promise<void> } | null
+    if (body?.cancel) {
+      try {
+        await body.cancel()
+      } catch {
+        // ignore
+      }
+    }
+  }
+}
+
+async function safeText(res: Response): Promise<string> {
+  try {
+    return (await res.text()).slice(0, 500)
+  } catch {
+    return '<no body>'
+  }
+}

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,0 +1,11 @@
+/**
+ * MCP (Model Context Protocol) client integration.
+ *
+ * Connect Tuplet to existing remote MCP servers and expose their tools to the
+ * agent. Zero-dependency Streamable HTTP client.
+ */
+
+export { McpManager } from './manager.js'
+export { McpConnection, sanitizeToolName, normalizeSchema, flattenContent } from './client.js'
+export { McpHttpClient, parseSseMessages, type FetchLike, type McpToolDef, type McpCallResult } from './http-client.js'
+export type { McpServerConfig, McpServerInfo } from './types.js'

--- a/src/mcp/manager.ts
+++ b/src/mcp/manager.ts
@@ -1,0 +1,82 @@
+/**
+ * MCP manager — owns connections to multiple MCP servers and aggregates their
+ * tools for a Tuplet agent.
+ *
+ * Lifecycle is host-managed (fits Tuplet's stateless design): construct once,
+ * `connect()`, pass `getTools()` into TupletConfig, `close()` when done. The
+ * host decides whether to reuse a manager across runs or connect per request.
+ */
+
+import type { Tool } from '../types.js'
+import type { McpServerConfig, McpServerInfo } from './types.js'
+import { McpConnection } from './client.js'
+
+export class McpManager {
+  private connections: McpConnection[]
+
+  constructor(servers: McpServerConfig[]) {
+    this.connections = servers.map(s => new McpConnection(s))
+  }
+
+  /**
+   * Connect to all configured servers in parallel. If any fail, the successful
+   * connections stay usable and an aggregate error is thrown listing failures —
+   * catch it to run degraded, or let it surface.
+   */
+  async connect(): Promise<void> {
+    const results = await Promise.allSettled(this.connections.map(c => c.connect()))
+    const failures = results
+      .map((r, i) =>
+        r.status === 'rejected'
+          ? `${this.connections[i].config.name}: ${r.reason instanceof Error ? r.reason.message : String(r.reason)}`
+          : null
+      )
+      .filter((m): m is string => m !== null)
+    if (failures.length > 0) {
+      throw new Error(`Failed to connect MCP server(s):\n${failures.join('\n')}`)
+    }
+  }
+
+  /** Aggregated tools from every connected server. Unconnected servers are skipped. */
+  getTools(): Tool[] {
+    return this.connections.filter(c => c.connected).flatMap(c => c.getTools())
+  }
+
+  /** Per-server summaries (name, description, tool count, connected state). */
+  getServerInfo(): McpServerInfo[] {
+    return this.connections.map(c => c.info())
+  }
+
+  /**
+   * A system-prompt block describing the connected servers so the agent knows
+   * what each is for. Append to the agent `role`, or register as a PromptSection.
+   * Returns '' when nothing is connected.
+   */
+  getPromptSection(): string {
+    const connected = this.connections.filter(c => c.connected)
+    if (connected.length === 0) return ''
+
+    const lines: string[] = [
+      '## Connected MCP servers',
+      '',
+      'You have access to tools from the external MCP servers below. Tool names are prefixed with the server name. If a tool is not already listed, load it with __tool_search__ before calling it.',
+      '',
+    ]
+    for (const c of connected) {
+      const info = c.info()
+      const heading = info.description ? `${info.name} — ${info.description}` : info.name
+      lines.push(`### ${heading}`)
+      lines.push(`- Tools: ${info.toolCount} (prefixed \`${info.name}__\`)`)
+      if (info.instructions) {
+        lines.push(`- Server notes: ${info.instructions.trim()}`)
+      }
+      lines.push('')
+    }
+    return lines.join('\n').trimEnd()
+  }
+
+  /** Close all connections. */
+  async close(): Promise<void> {
+    await Promise.allSettled(this.connections.map(c => c.close()))
+  }
+}

--- a/src/mcp/mcp.test.ts
+++ b/src/mcp/mcp.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest'
+import { McpConnection, sanitizeToolName, normalizeSchema, flattenContent } from './client.js'
+import { parseSseMessages, type FetchLike } from './http-client.js'
+import { McpManager } from './manager.js'
+import type { ToolContext } from '../types.js'
+
+const ctx: ToolContext = { remainingTokens: 1000 }
+
+/** A fake Streamable HTTP MCP server backed by a tool map. */
+function fakeServer(opts: {
+  tools?: Array<{ name: string; description?: string; inputSchema?: unknown }>
+  instructions?: string
+  json?: boolean
+  onCall?: (name: string, args: Record<string, unknown>) => { content: unknown; isError?: boolean }
+} = {}): FetchLike {
+  const tools = opts.tools ?? [
+    { name: 'echo', description: 'Echo text', inputSchema: { type: 'object', properties: { text: { type: 'string' } }, required: ['text'] } },
+  ]
+  return async (_url, init) => {
+    const body = JSON.parse(init.body as string) as { id?: number; method: string; params?: any }
+    if (body.method === 'notifications/initialized') {
+      return new Response(null, { status: 202 })
+    }
+    let result: unknown
+    if (body.method === 'initialize') {
+      result = { protocolVersion: '2025-06-18', capabilities: { tools: {} }, serverInfo: { name: 'fake', version: '1' }, instructions: opts.instructions }
+    } else if (body.method === 'tools/list') {
+      result = { tools }
+    } else if (body.method === 'tools/call') {
+      const { name, arguments: args } = body.params
+      result = opts.onCall ? opts.onCall(name, args) : { content: [{ type: 'text', text: `echo: ${args.text}` }] }
+    }
+    const payload = JSON.stringify({ jsonrpc: '2.0', id: body.id, result })
+    if (opts.json === false) {
+      const sse = `event: message\ndata: ${payload}\n\n`
+      return new Response(sse, { status: 200, headers: { 'content-type': 'text/event-stream', 'mcp-session-id': 'sess-1' } })
+    }
+    return new Response(payload, { status: 200, headers: { 'content-type': 'application/json', 'mcp-session-id': 'sess-1' } })
+  }
+}
+
+describe('helpers', () => {
+  it('sanitizeToolName strips invalid chars and caps length', () => {
+    expect(sanitizeToolName('gcal__list.events')).toBe('gcal__list_events')
+    expect(sanitizeToolName('a b/c')).toBe('a_b_c')
+    expect(sanitizeToolName('x'.repeat(80)).length).toBe(64)
+  })
+
+  it('normalizeSchema passes object schemas through and defaults otherwise', () => {
+    expect(normalizeSchema({ type: 'object', properties: { a: { type: 'string' } } })).toEqual({
+      type: 'object',
+      properties: { a: { type: 'string' } },
+    })
+    expect(normalizeSchema(undefined)).toEqual({ type: 'object', properties: {} })
+    expect(normalizeSchema({ type: 'object' })).toEqual({ type: 'object', properties: {} })
+  })
+
+  it('flattenContent joins text, resources, images', () => {
+    expect(flattenContent([{ type: 'text', text: 'hi' }, { type: 'text', text: 'bye' }])).toBe('hi\nbye')
+    expect(flattenContent([{ type: 'resource', resource: { uri: 'file://x' } }])).toBe('[resource: file://x]')
+    expect(flattenContent([{ type: 'image', mimeType: 'image/png' }])).toBe('[image image/png]')
+    expect(flattenContent('nope')).toBe('')
+  })
+
+  it('parseSseMessages extracts JSON-RPC payloads', () => {
+    const raw = 'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{"ok":true}}\n\n: ping\n\n'
+    const msgs = parseSseMessages(raw)
+    expect(msgs).toHaveLength(1)
+    expect(msgs[0].result).toEqual({ ok: true })
+  })
+})
+
+describe('McpConnection', () => {
+  it('connects, discovers, and wraps tools (namespaced)', async () => {
+    const conn = new McpConnection({ name: 'test', url: 'http://x', description: 'a test server' })
+    await conn.connect(fakeServer({ instructions: 'Use echo to repeat text.' }))
+    const tools = conn.getTools()
+    expect(tools).toHaveLength(1)
+    expect(tools[0].name).toBe('test__echo')
+    expect(tools[0].description).toBe('Echo text')
+    expect(tools[0].parameters.properties).toHaveProperty('text')
+
+    const res = await tools[0].execute({ text: 'hi' }, ctx)
+    expect(res.success).toBe(true)
+    expect(res.data).toBe('echo: hi')
+
+    const info = conn.info()
+    expect(info.connected).toBe(true)
+    expect(info.toolCount).toBe(1)
+    expect(info.instructions).toBe('Use echo to repeat text.')
+  })
+
+  it('parses SSE-framed responses', async () => {
+    const conn = new McpConnection({ name: 'test', url: 'http://x' })
+    await conn.connect(fakeServer({ json: false }))
+    const res = await conn.getTools()[0].execute({ text: 'yo' }, ctx)
+    expect(res.success).toBe(true)
+    expect(res.data).toBe('echo: yo')
+  })
+
+  it('surfaces tool errors as failed ToolResults', async () => {
+    const conn = new McpConnection({ name: 'test', url: 'http://x' })
+    await conn.connect(fakeServer({ onCall: () => ({ content: [{ type: 'text', text: 'boom' }], isError: true }) }))
+    const res = await conn.getTools()[0].execute({ text: 'x' }, ctx)
+    expect(res.success).toBe(false)
+    expect(res.error).toBe('boom')
+  })
+
+  it('applies allowTools / denyTools filters', async () => {
+    const server = fakeServer({
+      tools: [
+        { name: 'read', inputSchema: { type: 'object', properties: {} } },
+        { name: 'write', inputSchema: { type: 'object', properties: {} } },
+      ],
+    })
+    const allow = new McpConnection({ name: 's', url: 'http://x', allowTools: ['read'] })
+    await allow.connect(server)
+    expect(allow.getTools().map(t => t.name)).toEqual(['s__read'])
+
+    const deny = new McpConnection({ name: 's', url: 'http://x', denyTools: ['write'] })
+    await deny.connect(server)
+    expect(deny.getTools().map(t => t.name)).toEqual(['s__read'])
+  })
+
+  it('getTools throws before connect', () => {
+    const conn = new McpConnection({ name: 's', url: 'http://x' })
+    expect(() => conn.getTools()).toThrow(/not connected/)
+  })
+})
+
+describe('McpManager', () => {
+  it('aggregates tools and builds a prompt section', async () => {
+    const mgr = new McpManager([
+      { name: 'hubspot', url: 'http://a', description: 'CRM' },
+      { name: 'gcal', url: 'http://b', description: 'Calendar' },
+    ])
+    // Inject the fake transport by connecting each connection directly.
+    // Manager.connect() uses the real fetch, so drive connections via a custom path:
+    for (const c of (mgr as unknown as { connections: McpConnection[] }).connections) {
+      await c.connect(fakeServer({ instructions: 'server notes here' }))
+    }
+
+    const tools = mgr.getTools()
+    expect(tools.map(t => t.name).sort()).toEqual(['gcal__echo', 'hubspot__echo'])
+
+    const section = mgr.getPromptSection()
+    expect(section).toContain('## Connected MCP servers')
+    expect(section).toContain('hubspot — CRM')
+    expect(section).toContain('gcal — Calendar')
+    expect(section).toContain('server notes here')
+
+    const infos = mgr.getServerInfo()
+    expect(infos).toHaveLength(2)
+    expect(infos.every(i => i.connected)).toBe(true)
+  })
+
+  it('getPromptSection is empty when nothing is connected', () => {
+    const mgr = new McpManager([{ name: 'x', url: 'http://a' }])
+    expect(mgr.getPromptSection()).toBe('')
+    expect(mgr.getTools()).toEqual([])
+  })
+})

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,0 +1,38 @@
+/**
+ * MCP (Model Context Protocol) client types.
+ *
+ * Tuplet acts purely as an MCP *client* — it connects to existing remote MCP
+ * servers and exposes their tools as native Tuplet tools. It does not implement
+ * servers. Only the Streamable HTTP transport is supported (the transport used
+ * by hosted servers such as HubSpot, Close, and Google Calendar).
+ */
+
+/** Remote MCP server reachable over Streamable HTTP. */
+export interface McpServerConfig {
+  /** Short identifier used to namespace this server's tools (e.g. 'hubspot'). */
+  name: string
+  /** Endpoint URL of the MCP server. */
+  url: string
+  /**
+   * Sent on every request. Use for auth: bearer tokens, API keys, scope headers
+   * (e.g. `{ Authorization: 'Bearer ...', 'Close-Scope': 'mcp.read' }`).
+   */
+  headers?: Record<string, string>
+  /** Human description of what the server is for. Surfaced to the agent. */
+  description?: string
+  /** If set, only expose tools whose original (un-prefixed) name is listed. */
+  allowTools?: string[]
+  /** If set, hide tools whose original (un-prefixed) name is listed. */
+  denyTools?: string[]
+}
+
+/** Summary of a connected server, used to build agent context. */
+export interface McpServerInfo {
+  name: string
+  description?: string
+  /** Usage instructions the server itself advertised on connect, if any. */
+  instructions?: string
+  /** Number of tools exposed after filtering. */
+  toolCount: number
+  connected: boolean
+}


### PR DESCRIPTION
Connect existing remote MCP servers (Streamable HTTP) and expose their tools as native Tuplet tools. Tuplet acts purely as an MCP client.

- src/mcp: hand-rolled Streamable HTTP JSON-RPC client (no SDK, zero deps), McpConnection (tool wrapping, ${server}__${tool} namespacing, inputSchema pass-through, content flattening, allow/deny filtering), McpManager (multi-server connect/getTools/close + getPromptSection for agent context)
- Exported from the main entry point
- MCP tools auto-defer through the existing __tool_search__ mechanism
- Wired into examples/eating-consultant via MCP_* env vars
- docs/mcp.md, README feature bullet, 11 unit tests